### PR TITLE
fix evolution.dependencies

### DIFF
--- a/evolution.dependencies
+++ b/evolution.dependencies
@@ -14,6 +14,6 @@
     {
       "remote":"github",
       "repository":"CannedShroud/android_kernel_xiaomi_lisa-temp",
-      "target_path":"kernel/xiaomi/lisa",
-    },
+      "target_path":"kernel/xiaomi/lisa"
+    }
 ]


### PR DESCRIPTION
the syntax of the json is incorrect which raises an exception crashing vendor/evolution/build/tools/roomservice.py